### PR TITLE
Silence some warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,4 +76,4 @@ DEPENDENCIES
   safe-pg-migrations!
 
 BUNDLED WITH
-   1.16.5
+   2.3.4

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -79,7 +79,7 @@ module SafePgMigrations
     # Rails >= 6.1 signature: remove_index(table_name, column_name = nil, **options)
     # Rails <  6.1 signature: remove_index(table_name, options = {})
     # NOTE: This currently only supports Rails >= 6.1
-    ruby2_keywords def remove_index(table_name, column_name = nil, **options)
+    def remove_index(table_name, column_name = nil, **options)
       options[:algorithm] = :concurrently unless options.key?(:algorithm)
 
       SafePgMigrations.say_method_call(:remove_index, table_name, column_name, **options)

--- a/test/useless_statement_logger_test.rb
+++ b/test/useless_statement_logger_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class UselessStatementLoggerTest < MiniTest::Unit::TestCase
+class UselessStatementLoggerTest < MiniTest::Test
   def setup
     SafePgMigrations.instance_variable_set(:@config, nil)
     @connection = ActiveRecord::Base.connection


### PR DESCRIPTION
1. Remove extraneous "ruby2_keywords"
This isn't needed anymore and we were getting this warning message in our app:

        lib/safe-pg-migrations/plugins/statement_insurer.rb:82: warning: Skipping
        set of ruby2_keywords flag for remove_index (method accepts keywords or
        method does not accept argument splat)

2. Update bundler
To fix warning seen while running tests:

        bundler-1.16.5/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint
        is deprecated and will be removed in Ruby 3.2.

3. Fix "MiniTest::Test" warning
To fix warning seen while running tests:

        MiniTest::Unit::TestCase is now Minitest::Test. From
        safe-pg-migrations/test/useless_statement_logger_test.rb:5:in `<top
        (required)>'

I'm creating a separate PR to attempt to get some of these into the upstream repo.